### PR TITLE
feat: url contract path

### DIFF
--- a/packages/presets/src/scripts/deploy-app.ts
+++ b/packages/presets/src/scripts/deploy-app.ts
@@ -64,6 +64,7 @@ export async function deployApp() {
     await uploadFile({ deployer, fileContract, fileContents, filename, partitions, isLive, application });
   }
 
+  console.log(`your application is now available at http://ec2-54-185-81-147.us-west-2.compute.amazonaws.com/${fileContract}/${deployerAccount}/${application}`)
   console.log(`all files uploaded for ${application}, beginning post-deploy actions`)
   if (isLive) {
     const cleanupResult = await postDeployCleanup({ deployer, fileContract, application });


### PR DESCRIPTION
This PR updates the web service to encode the filestore contract within content URLs; e.g. `/andy.near/application` is now `v1.chainui.near/andy.near/application`. This change has already been applied to the EC2 instance